### PR TITLE
Feature: add defaultTimeout property with default 5 seconds instead o…

### DIFF
--- a/src/test/java/xyz/npgw/test/common/BrowserFactory.java
+++ b/src/test/java/xyz/npgw/test/common/BrowserFactory.java
@@ -39,7 +39,8 @@ public enum BrowserFactory {
         return new BrowserType
                 .LaunchOptions()
                 .setHeadless(ProjectProperties.isHeadlessMode())
-                .setSlowMo(ProjectProperties.getSlowMoMode());
+                .setSlowMo(ProjectProperties.getSlowMoMode())
+                .setTimeout(ProjectProperties.getDefaultTimeout());
     }
 
     public abstract Browser createInstance(Playwright playwright);

--- a/src/test/java/xyz/npgw/test/common/ProjectProperties.java
+++ b/src/test/java/xyz/npgw/test/common/ProjectProperties.java
@@ -31,6 +31,7 @@ public final class ProjectProperties {
 
     private static final String CLOSE_BROWSER_IF_ERROR = PREFIX_PROP + "closeBrowserIfError";
     private static final String ARTEFACT_DIR = PREFIX_PROP + "artefactDir";
+    private static final String DEFAULT_TIMEOUT = PREFIX_PROP + "defaultTimeout";
 
     private static final String ENV_APP_OPTIONS = "APP_OPTIONS";
 
@@ -106,6 +107,10 @@ public final class ProjectProperties {
 
     public static String getArtefactDir() {
         return properties.getProperty(ARTEFACT_DIR, "target/artefact");
+    }
+
+    public static double getDefaultTimeout() {
+        return Double.parseDouble(properties.getProperty(DEFAULT_TIMEOUT, "5000"));
     }
 
     public static String getSuperEmail() {


### PR DESCRIPTION
Add defaultTimeout property with default value = 5 seconds instead of 30 seconds that playwright waits by default before falling a test with timeout, test run will be a little faster.