### PR TITLE
[ATC_06.017.01] Verify, that 'Reset filter' cleans 'Company' field to empty add Company reset test

### DIFF
--- a/src/test/java/xyz/npgw/test/page/common/SelectCompanyComponent.java
+++ b/src/test/java/xyz/npgw/test/page/common/SelectCompanyComponent.java
@@ -82,4 +82,21 @@ public class SelectCompanyComponent<CurrentPageT> extends BaseComponent {
 
         return page;
     }
+
+    @Step("Select first company in dropdown")
+    public CurrentPageT selectFirstCompany() {
+        if (dropdownOptionList.all().isEmpty()) {
+            throw new NoSuchElementException("Dropdown list is empty.");
+        }
+        else {
+            dropdownOptionList.first().click();
+        }
+
+        return page;
+    }
+
+    public String firstCompanyName(){
+
+        return  dropdownOptionList.first().textContent();
+    }
 }

--- a/src/test/java/xyz/npgw/test/run/TransactionsPageTest.java
+++ b/src/test/java/xyz/npgw/test/run/TransactionsPageTest.java
@@ -852,6 +852,34 @@ public class TransactionsPageTest extends BaseTest {
         assertEquals(totalRowsAfterFilter, numberWithStatusesAfterFilter);
     }
 
+    @Test
+    @TmsLink("686")
+    @Epic("Transactions")
+    @Feature("Reset filter button")
+    @Description("Verify, that 'Reset filter' clean 'Company' input field")
+    public void testResetCompany() {
+        TransactionsPage transactionsPage = new DashboardPage(getPage())
+                .clickTransactionsLink();
+
+        Allure.step("Verify: the 'Company' input field is empty by default");
+        assertThat(transactionsPage.getSelectCompany().getSelectCompanyField()).isEmpty();
+
+        transactionsPage.getSelectCompany().clickSelectCompanyDropdownChevron()
+                        .getSelectCompany().clickSelectCompanyField()
+                        .getSelectCompany().selectFirstCompany();
+
+        String firstCompanyName = transactionsPage.getSelectCompany().firstCompanyName();
+
+        Allure.step("Verify: selected company is displayed in the 'Company' input field");
+        assertThat(transactionsPage.getSelectCompany().getSelectCompanyField()).hasValue(firstCompanyName);
+
+        transactionsPage.clickResetFilterButton();
+
+        Allure.step("Verify: the 'Company' input field is empty after reset");
+        assertThat(transactionsPage.getSelectCompany().getSelectCompanyField()).isEmpty();
+
+    }
+
     @AfterClass
     @Override
     protected void afterClass() {


### PR DESCRIPTION
[[ATC_06.017.01] Verify, that 'Reset filter' cleans 'Company' field to empty ](https://github.com/NPGW/npgw-ui-test/issues/686)