### PR TITLE
[ATC-07.008.01] Sorting Reports by Size displays entries in ascending and descending order by size

### DIFF
--- a/src/test/java/xyz/npgw/test/page/common/table/ReportsTableComponent.java
+++ b/src/test/java/xyz/npgw/test/page/common/table/ReportsTableComponent.java
@@ -27,7 +27,7 @@ public class ReportsTableComponent extends BaseTableComponent<ReportsPage> {
     }
 
     @Step("Click the 'Size' column header")
-    public ReportsPage clickSizeColumnHeader(){
+    public ReportsPage clickSizeColumnHeader() {
         sizeColumnHeader. click();
 
         return new ReportsPage(getPage());

--- a/src/test/java/xyz/npgw/test/page/common/table/ReportsTableComponent.java
+++ b/src/test/java/xyz/npgw/test/page/common/table/ReportsTableComponent.java
@@ -12,6 +12,7 @@ public class ReportsTableComponent extends BaseTableComponent<ReportsPage> {
     }
 
     private final Locator filenameColumnHeader = getByRole(AriaRole.COLUMNHEADER, "Filename");
+    private final Locator sizeColumnHeader = getByRole(AriaRole.COLUMNHEADER, "Size");
 
     @Override
     protected ReportsPage getCurrentPage() {
@@ -21,6 +22,13 @@ public class ReportsTableComponent extends BaseTableComponent<ReportsPage> {
     @Step("Click the 'Filename' column header")
     public ReportsPage clickFilenameColumnHeader() {
         filenameColumnHeader.click();
+
+        return new ReportsPage(getPage());
+    }
+
+    @Step("Click the 'Size' column header")
+    public ReportsPage clickSizeColumnHeader(){
+        sizeColumnHeader. click();
 
         return new ReportsPage(getPage());
     }

--- a/src/test/java/xyz/npgw/test/run/ReportsPageTest.java
+++ b/src/test/java/xyz/npgw/test/run/ReportsPageTest.java
@@ -222,6 +222,36 @@ public class ReportsPageTest extends BaseTest {
                 "Filenames are not in reverse alphabetical order");
     }
 
+    @Test
+    @TmsLink("718")
+    @Epic("Reports")
+    @Feature("Table entries sorting")
+    @Description("'Size' column header sorts entries in ascending and descending order")
+    public void testSortingBySize() {
+        ReportsPage reportsPage = new ReportsPage(getPage())
+                .clickReportsLink()
+                .getTable().clickSizeColumnHeader();
+
+        List<String> actualSizeList = reportsPage.getTable().getColumnValues("Size");
+        List<String> sortedSizeListAsc = new ArrayList<String>(actualSizeList);
+        Collections.sort(sortedSizeListAsc);
+
+        Allure.step("Verify that entries are displayed in ascending order by Size");
+        Assert.assertEquals(actualSizeList, sortedSizeListAsc,
+                "Filenames are not in alphabetical order");
+
+        reportsPage
+                .getTable().clickSizeColumnHeader();
+
+        actualSizeList = reportsPage.getTable().getColumnValues("Size");
+        List<String> sortedSizeListDesc = new ArrayList<String>(sortedSizeListAsc);
+        Collections.reverse(sortedSizeListDesc);
+
+        Allure.step("Verify that entries are displayed in descending order by Size");
+        Assert.assertEquals(actualSizeList, sortedSizeListDesc,
+                "Filenames are not in alphabetical order");
+    }
+
     @AfterClass
     @Override
     protected void afterClass() {


### PR DESCRIPTION
[[ATC-07.008.01] Sorting Reports by Size displays entries in ascending and descending order by size](https://github.com/NPGW/npgw-ui-test/issues/718)