### PR TITLE
[ATC_11.001.11] Acquirers | Setup acquirer MID dialog | The "Challenge URL", "Resource URL", and "Fingerprint URL" fields accept URLs with valid srtuctures check

### DIFF
--- a/src/test/java/xyz/npgw/test/run/AcquirersPageTest.java
+++ b/src/test/java/xyz/npgw/test/run/AcquirersPageTest.java
@@ -941,7 +941,7 @@ public class AcquirersPageTest extends BaseTestForSingleLogin {
     @Epic("System/Acquirers")
     @Feature("Setup acquirer MID")
     @Description("Verify: Url fields in the 'Setup acquirer MID' dialog accept Valid URL structures")
-    public void testUrlFieldsAcceptValidUrlStructures () {
+    public void testUrlFieldsAcceptValidUrlStructures() {
         SetupAcquirerMidDialog setupAcquirerMidDialog = new SuperDashboardPage(getPage())
                 .getHeader().clickSystemAdministrationLink()
                 .clickAcquirersTab()
@@ -968,10 +968,10 @@ public class AcquirersPageTest extends BaseTestForSingleLogin {
                     .fillFingerprintUrlField(url)
                     .fillResourceUrlField(url);
 
-            Allure.step("Verify: 'ChallengeUrl' field accept" + url + "URL");
+            Allure.step("Verify: 'Create button' is enabled for URL fields filled with value:" + url);
             Assert.assertTrue(
                     setupAcquirerMidDialog.getCreateButton().isEnabled(),
-                    "Create button is disabled for URL: " + url
+                    "'Create button' is disabled for URL fields filled with value:" + url
             );
         }
     }


### PR DESCRIPTION
[[ATC_11.001.11] Acquirers | Setup acquirer MID dialog | The "Challenge URL", "Resource URL", "Fingerprint URL" fields accept URLs with different structure check](https://github.com/NPGW/npgw-ui-test/issues/1206)